### PR TITLE
Return some reasonably top safeArea for ios < 11.

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -3,7 +3,7 @@
  */
 'use strict'
 
-import { NativeModules, NativeEventEmitter } from 'react-native'
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native'
 import type EmitterSubscription from 'EmitterSubscription'
 
 export type SafeAreaInsets = { top: number, left: number, bottom: number, right: number };
@@ -13,7 +13,9 @@ const nativeEventEmitter = new NativeEventEmitter(nativeModule)
 
 class SafeArea {
   getSafeAreaInsetsForRootView(): Promise<{ safeAreaInsets: SafeAreaInsets }> {
-    return nativeModule.getSafeAreaInsetsForRootView()
+    return parseInt(Platform.Version, 10) >= 11
+      ? nativeModule.getSafeAreaInsetsForRootView()
+      : { top: 20, left: 0, bottom: 0, right: 0 }
   }
 
   addEventListener(eventType: string, listener: Function, context: ?Object): ?EmitterSubscription {


### PR DESCRIPTION
Eailer it was returning 0 for iOS < 11, thus making content to overlap status bar.