### PR TITLE
Fix TS definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,19 @@
-/// <reference types="react" />
 
 declare module 'react-native-safe-area' {
+    import { ComponentType } from 'react'
 
     // from `TypeDefinition.js`
     type SafeAreaInsets = { top: number; left: number; bottom: number; right: number };
 
+    type EventType = 'safeAreaInsetsForRootViewDidChange'
+
+    type EventPayload = { safeAreaInsets: SafeAreaInsets }
+
     // from `SafeArea.[ios|android].js`
     export default class SafeArea {
-        static getSafeAreaInsetsForRootView(): Promise<{ safeAreaInsets: SafeAreaInsets }> {}
-        static addEventListener(eventType: string, listener: (...args: any[]) => any, context?: any) 
-        static removeEventListener(eventType: string, listener: (...args: any[]) => any) 
+        static getSafeAreaInsetsForRootView(): Promise<EventPayload>
+        static addEventListener(eventType: EventType, listener: (payload: EventPayload) => void): void 
+        static removeEventListener(eventType: EventType, listener: (payload: EventPayload) => void): void
     }
 
     // from `withSafeArea.js`
@@ -34,9 +38,15 @@ declare module 'react-native-safe-area' {
         | 'horizontalAndBottom'
         | 'all';
 
-    export function withSafeArea(
-        WrappedComponent: React.ComponentType<any>,
-        applyTo: 'margin' | 'padding' | 'absolutePosition' | 'contentInset' = 'margin',
-        direction: Direction = 'all',
-    ): React.ComponentType<any>;
+    export function withSafeArea<P>(
+        WrappedComponent: React.ComponentType<P>,
+        /**
+         * @default 'margin'
+         */
+        applyTo: 'margin' | 'padding' | 'absolutePosition' | 'contentInset',
+        /**
+         * @default 'all'
+         */
+        direction: Direction,
+    ): ComponentType<P>;
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.0",
   "description": "React Native module to get Safe Area Insets for iOS 11 or later",
   "main": "lib/index",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint lib",
     "flow": "flow --show-all-errors",
@@ -34,5 +35,8 @@
     "flow-bin": "^0.86.0",
     "react": "^16.8.3",
     "react-native": "^0.58.6"
+  },
+  "dependencies": {
+    "@types/react": "^16.8.8"
   }
 }


### PR DESCRIPTION
Typescript definitions were broken, see screenshot bellow.

## Summary of changes

- Add explicit dependency to @types/react as recommended in Typescript official guidelines
- Add types entry in package.json as recommended in Typescript official guidelines
- Fix few type errors
- Fix ambiant declaration
- Add more accurate addEventListener and removeEventListener signatures

## Before

*typescript 3.1*

![image](https://user-images.githubusercontent.com/3646758/54757897-6f681280-4beb-11e9-87c8-b5f393e9bde4.png)

## After

![image](https://user-images.githubusercontent.com/3646758/54758045-b9e98f00-4beb-11e9-847e-fc66a1fce0da.png)

