### PR TITLE
fix: Type definiton for `withSafeArea`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,10 +43,10 @@ declare module 'react-native-safe-area' {
         /**
          * @default 'margin'
          */
-        applyTo: 'margin' | 'padding' | 'absolutePosition' | 'contentInset',
+        applyTo?: 'margin' | 'padding' | 'absolutePosition' | 'contentInset',
         /**
          * @default 'all'
          */
-        direction: Direction,
+        direction?: Direction,
     ): ComponentType<P>;
 }


### PR DESCRIPTION
- all parameteres except the first are optional